### PR TITLE
Add missing filter in Power Plant Register

### DIFF
--- a/serial_views.py
+++ b/serial_views.py
@@ -110,6 +110,7 @@ def ppr_view(request):
                 tbl_cols = Bundle(
                     'powerplant',
                     res_powerplant_tbl.id,
+                    res_powerplant_tbl.version,
                     res_powerplant_tbl.generation_type,
                     res_powerplant_tbl.generation_subtype,
                     res_powerplant_tbl.scenario
@@ -124,6 +125,7 @@ def ppr_view(request):
                         and_(
                             # tbl_cols.c.rea_geom_new.ST_Transform(4326).ST_Within(wkb),
                             res_powerplant_tbl.rea_geom_new.ST_Transform(4326).ST_Within(wkb),
+                            tbl_cols.c.version == EGO_DP_VERSION,
                             tbl_cols.c.scenario == EGO_DP_SCENARIO,
                             tbl_cols.c.generation_type == generation_type
                         )
@@ -263,6 +265,7 @@ def ppr_popup_view(request):
                 .filter(
                     and_(
                         tbl_cols_property.c.version == EGO_DP_VERSION,
+                        tbl_cols_property.c.scenario == EGO_DP_SCENARIO,
                         tbl_cols_property.c.id == pp_id
                     )
                 )


### PR DESCRIPTION
There are filter options missing in ppr_view and ppr_popup_view.

Closes #96 