### PR TITLE
Transform from 3035 to 4326

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ oedialect
 python-dateutil
 configobj
 git+https://github.com/coroa/saio.git#egg=saio
-pyproj

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ oedialect
 python-dateutil
 configobj
 git+https://github.com/coroa/saio.git#egg=saio
+pyproj

--- a/saio_table_models.py
+++ b/saio_table_models.py
@@ -2,6 +2,5 @@ import sqlahelper as sah
 import saio
 
 saio.register_schema("model_draft", sah.get_engine('oep_engine'))
-saio.register_schema("supply", sah.get_engine('oep_engine'))
 from saio.model_draft import openfred_timeseries_wind_2016 as Timeseries
-from saio.supply import ego_dp_res_powerplant as Powerplants
+from saio.model_draft import openfred_powerplants as Powerplants

--- a/serial_views.py
+++ b/serial_views.py
@@ -12,6 +12,7 @@ from geoalchemy2.elements import WKTElement
 from shapely.geometry import shape
 from shapely.wkb import loads as loadswkb
 from dateutil import parser
+from pyproj import Proj, transform
 
 from .saio_table_models import (
     Timeseries,
@@ -40,6 +41,9 @@ TIME_STEPS = {
 EGO_DP_VERSION = fred_config['WAM_APP_FRED']['EGO_DP_VERSION']
 EGO_DP_SCENARIO = fred_config['WAM_APP_FRED']['SCENARIO']
 OEP_ACCESS = fred_config['WAM_APP_FRED']['OEP_ACCESS']
+
+P3035 = Proj(init='epsg:3035')
+P4326 = Proj(init='epsg:4326')
 
 
 class Serializer(View):
@@ -158,22 +162,14 @@ def ppr_view(request):
                 Powerplants.scenario
             )
             # create query
-            if OEP_ACCESS == 'OEP_DIALECT':
-                # TODO find a way to convert the column rea_geom_new to srid 4326
-                geom = Powerplants.geom
-                cond_geom = tbl_cols.c.nuts.in_([region_nut])
-            elif OEP_ACCESS == 'OEP':
-                geom = Powerplants.rea_geom_new
-                wkb = Serializer.regions_wkbs[region_name]
-                cond_geom = tbl_cols.c.rea_geom_new.ST_Transform(4326).ST_Within(wkb)
-
             oep_query = Serializer.session.query(
-                geom,
+                Powerplants.geom,
+                Powerplants.rea_geom_new,
                 tbl_cols
             ) \
                 .filter(
                     and_(
-                        cond_geom,
+                        tbl_cols.c.nuts.in_([region_nut]),
                         tbl_cols.c.version == EGO_DP_VERSION,
                         tbl_cols.c.scenario == EGO_DP_SCENARIO,
                         tbl_cols.c.generation_type == generation_type
@@ -184,12 +180,13 @@ def ppr_view(request):
 
             # TODO find a way not to limit the query
             for record in oep_query.limit(1000):
-                # TODO
-                # this might need to be translated to 4326!!!
-                region_contains = loadswkb(str(record[0]), True)
+                pos = shape(loadswkb(str(record[0]), True))
+                # translate from 3035 to 4326
+                # TODO this takes time!!!
+                pos = Point(transform(P3035, P4326, pos.x, pos.y))
                 feature = Feature(
                     id=record.powerplant.id,
-                    geometry=region_contains,
+                    geometry=pos,
                     property=dict(
                         region_nut=region_nut,
                         region_name=region_name,
@@ -198,6 +195,7 @@ def ppr_view(request):
                     )
                 )
                 myfeatures.append(feature)
+
         else:
             landkreis_ids = Serializer.regions_to_landkreis[region_nut]
             for lk_id in landkreis_ids:


### PR DESCRIPTION
@Ludee, @christian-rli @jh-RLI  - is there a reason why is the column geom in srid 4326 and the column rea_geom_new in srid 3035 in this [register](https://openenergy-platform.org/dataedit/view/supply/ego_dp_res_powerplant)?
The conversion from 3035 into 4326 make the query for 1000 units go from 1.5 s to 30 s ... (because oedialect doesn't handle the ST_Transform unfortunately...)



